### PR TITLE
Add special characters example

### DIFF
--- a/IIIFpres/iiifpapi3.py
+++ b/IIIFpres/iiifpapi3.py
@@ -77,7 +77,7 @@ global CONTEXT
 CONTEXT = "http://iiif.io/api/presentation/3/context.json"
 global INVALID_URI_CHARACTERS
 # removed comma which is used by IIIF Image API and #
-INVALID_URI_CHARACTERS = r"""!"$%&'()*+ :;<=>?@[\]^`{|}~ """
+INVALID_URI_CHARACTERS = r"""!"$&'()*+ :;<=>?@[\]^`{|}~ """
 global BEHAVIOURS
 BEHAVIOURS = ["auto-advance",
               "no-auto-advance",

--- a/examples/Example_spcecial_characters.py
+++ b/examples/Example_spcecial_characters.py
@@ -1,0 +1,39 @@
+from IIIFpres import iiifpapi3
+import urllib.parse
+iiifpapi3.BASE_URL = "https://example.org/iiif/book1/"
+manifest = iiifpapi3.Manifest()
+manifest.set_id(extendbase_url="manifest.json")
+manifest.add_label("en","Special characters in URL")
+manifest.add_behavior("paged")
+
+data = (("Colon in URL",2060,1553,"https://www.nb.no/services/image/resolver/URN%3ANBN%3Ano-nb_digibok_2009070210001_0618/info.json","/full/max/0/default.jpg"),
+        ("Exclamation mark in URL",3186,4612,"https://iiif.library.ethz.ch/iiif/2/e-periodica!zui!1938_014!zui-001_1938_014_0634.jpg/info.json","/full/max/0/default.jpg"),)
+
+for idx,d in enumerate(data):
+    idx+=1 
+    canvas = iiifpapi3.Canvas()
+    canvas.set_id(extendbase_url="canvas/p%s"%idx) # in this case we use the base url
+    canvas.set_height(d[2])
+    canvas.set_width(d[1])
+    canvas.add_label("en",d[0])
+    annopage = iiifpapi3.AnnotationPage()
+    annopage.set_id(extendbase_url="page/p%s/1" %idx)
+    annotation = iiifpapi3.Annotation(target=canvas.id)
+    annotation.set_id(extendbase_url="annotation/p%s-image"%str(idx).zfill(4))
+    annotation.set_motivation("painting")
+    url = "".join(urllib.parse.quote(str(d[3]),safe='/')).replace('%3A', ':', 1)
+    annotation.body.set_id("".join(url))
+    annotation.body.set_type("Image")
+    annotation.body.set_format("image/jpeg")
+    annotation.body.set_width(d[1])
+    annotation.body.set_height(d[2])
+    s = iiifpapi3.service()
+    s.set_id(url)
+    s.set_type("ImageService3")
+    s.set_profile("level1")
+    annotation.body.add_service(s)
+    annopage.add_item(annotation)
+    canvas.add_item(annopage)
+    manifest.add_item(canvas)
+
+manifest.json_save("manifest.json")


### PR DESCRIPTION
Hi @giacomomarchioro 

I encountered problems when creating manifests that contain IIIF URLs with special characters:

```python
I found: : here. 
/www.nb.no/services/image/resolver/URN:NBN:no-nb_digibok_2009070210001_0618/info.json
                                          ^
Traceback (most recent call last):
  File "/data/snip/pyIIIFpres/examples/simple_book.py", line 32, in <module>
    annotation.body.set_id("".join(url))
  File "/data/snip/pyIIIFpres/venv/lib/python3.12/site-packages/IIIFpres/iiifpapi3.py", line 312, in set_id
    self.id = check_ID(self, extendbase_url, objid)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/snip/pyIIIFpres/venv/lib/python3.12/site-packages/IIIFpres/iiifpapi3.py", line 268, in check_ID
    assert check_valid_URI(objid), "Special characters must be encoded"
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Special characters must be encoded
```
The expression `INVALID_URI_CHARACTERS = r"""!"$%&'()*+ :;<=>?@[\]^``{|}~ """` seems a bit too eager as it clashes with percent-encoded paths.

This PR attempts to fix this by removing `%` from invalid characters and adding a small example to indicate a possible way to encode the URLs/IDs.

Of course feel free to solve it on a lower level in the codebase.

Apologies if this is a non-issue and already covered; I didn't spot it in the documentation, so a pointer would be appreciated in case.